### PR TITLE
Fix error and add connectionName

### DIFF
--- a/Import-RegisteredServers.ps1
+++ b/Import-RegisteredServers.ps1
@@ -22,6 +22,7 @@ begin {
 }
 
 process {
+    Import-Module SqlServer -DisableNameChecking
     $RegisteredServers = Get-ChildItem SQLSERVER:\SQLRegistration -Recurse | Where-Object {$_.ServerType -eq "DatabaseEngine"}
     $RegisteredServers.Refresh()
     $ServerGroups = $RegisteredServers | Where-Object {$_.ServerName -eq $null}
@@ -70,6 +71,8 @@ process {
     }    
     ForEach ($s in $Servers) {
         $ParentID = $UserSettings."datasource.connectionGroups" | Where-Object {$_.Name -eq $s.parent.displayname}
+        Write-Output $s.name
+        
         if (($UserSettings."datasource.connections" | Where-Object {$_.options.server -eq $s.ServerName -and $_.groupID -eq $ParentID.id}) -eq $null) {
             $dbUser = "";
             $dbPassword = "";
@@ -83,6 +86,7 @@ process {
             }
             $Connection = [PSCustomObject] @{
                 options = [PSCustomObject] @{
+                    connectionName=$s.name
                     server=$s.ServerName
                     database="master"
                     authenticationType=$AuthenticationType

--- a/Import-RegisteredServers.ps1
+++ b/Import-RegisteredServers.ps1
@@ -70,9 +70,7 @@ process {
         $UserSettings | Add-Member -Name 'datasource.connections' -MemberType NoteProperty -Value @() | Out-Null
     }    
     ForEach ($s in $Servers) {
-        $ParentID = $UserSettings."datasource.connectionGroups" | Where-Object {$_.Name -eq $s.parent.displayname}
-        Write-Output $s.name
-        
+        $ParentID = $UserSettings."datasource.connectionGroups" | Where-Object {$_.Name -eq $s.parent.displayname}        
         if (($UserSettings."datasource.connections" | Where-Object {$_.options.server -eq $s.ServerName -and $_.groupID -eq $ParentID.id}) -eq $null) {
             $dbUser = "";
             $dbPassword = "";


### PR DESCRIPTION
Fix error "Cannot find drive. A drive with the name 'SQLSERVER' does not exist."
Insert connectionName into the json connection object.